### PR TITLE
Fix for Perl regex and stdout buffering issue

### DIFF
--- a/lib/.ctagsrc
+++ b/lib/.ctagsrc
@@ -79,5 +79,5 @@
 --regex-js=/([^= ]+)[ \t]*=[ \t]*[^"]'[^']*/\1/,string/
 --regex-js=/([^= ]+)[ \t]*=[ \t]*[^']"[^"]*/\1/,string/
 
---regex-perl=/sub\s+([a-zA-Z0-9_]+)/\1/d,function/i
---regex-perl=/package\s+([a-zA-Z0-9_:]+)/\1/d,package/i
+--regex-perl=/sub[ \t]+([a-zA-Z0-9_]+)/\1/d,function/i
+--regex-perl=/package[ \t]+([a-zA-Z0-9_:]+)/\1/d,package/i

--- a/lib/ctags.coffee
+++ b/lib/ctags.coffee
@@ -34,14 +34,15 @@ class Ctags
     args = []
     args.push("--options=#{presets}", '--fields=+Kn', '--excmd=p')
     args.push('-R', '-f', '-', path)
-
+    tags = []
     stdout = (lines) =>
-      tags = @parseTags lines
+      tmp_tags = @parseTags lines
+      tags.push tmp_tags...
       tags.sort((x, y) -> x.start - y.start)  # Sort line_no by asc order
-
+    exit = (exitCode) =>
       callback tags
 
     stderr = (lines) ->
       console.warn lines
 
-    subprocess = new BufferedProcess({command, args, stdout, stderr})
+    subprocess = new BufferedProcess({command, args, stdout, stderr, exit})


### PR DESCRIPTION
Hi.

Couple of small fixes. First, seems like \s is not supported in ctags regex engine, I replaced it with [ \t]
Also, since BufferedProcess can call 'stdout' callback multiple times, you have to collect all output before storing it in cache. On my machine it was always using only first 64 tags because of it.
